### PR TITLE
use synset.lemma_names() to get words out of synsets

### DIFF
--- a/auto_c_hypo.py
+++ b/auto_c_hypo.py
@@ -1,26 +1,24 @@
 #imports
 from nltk.corpus import wordnet as wn
-import re
 
 #bank
 words = []
 
-#parsing utilities
-def return_words_one(entry):
-    h_bank = []
-    h_bank.append(str(entry))
-    regex = r'\w+'
-    result = re.findall(regex, h_bank[0])
-    print result[1]+',',
+#helpers
+def word_list_without_duplicates(word_list):
+    # remove duplicates by putting in a set
+    word_list = set(word_list)
+    # join word_list together with commas
+    return ', '.join(word_list)
 
-def return_words_two(entry):
-    h_bank = []
-    h_bank.append(str(lemma))
-    regex = r'\w+'
-    result = re.findall(regex, h_bank[0])
-    print result[1]+',',
-    print result[4]+',',
-
+def related_synsets(synset):
+    return (
+        synset.hyponyms() +
+        synset.part_holonyms() +
+        synset.substance_holonyms() +
+        synset.part_meronyms() +
+        synset.substance_meronyms()
+    )
 
 #loop
 while True:
@@ -32,54 +30,36 @@ while True:
     split_input = input_text.split()
     print " "
     for word in split_input:
-        try:
-            print "--"+word.upper()+"--NOUN--",
-            ss = wn.synsets(word, 'n')
-            for i in ss:
-                for entry in i.hyponyms():
-                    return_words_one(entry)
-                for entry in i.part_holonyms():
-                    return_words_one(entry)
-                for entry in i.substance_holonyms():
-                    return_words_one(entry)
-                for entry in i.part_meronyms():
-                    return_words_one(entry)
-                for entry in i.substance_meronyms():
-                    return_words_one(entry)
-        except IndexError:
-            pass
-        try:
-            print "--"+word.upper()+"--VERB--",
-            ss = wn.synsets(word, 'v')
-            for i in ss:
-                for entry in i.hyponyms():
-                    return_words_one(entry)
-                for entry in i.part_holonyms():
-                    return_words_one(entry)
-                for entry in i.substance_holonyms():
-                    return_words_one(entry)
-                for entry in i.part_meronyms():
-                    return_words_one(entry)
-                for entry in i.substance_meronyms():
-                    return_words_one(entry)
-        except IndexError:
-            pass
-        try:
-            print "--"+word.upper()+"--ADJ--",
-            token_a = wn.synsets(word, 'a')
-            for i in token_a:
-                for lemma in i.lemmas():
-                    return_words_two(entry)
-        except IndexError:
-            pass
-        try:
-            print "--"+word.upper()+"--ADV--",
-            token_r = wn.synsets(word, 'r')
-            for i in token_r:
-                for lemma in i.lemmas():
-                    return_words_two(entry)
-        except IndexError:
-            pass
+        print "--"+word.upper()+"--NOUN--",
+        synsets = wn.synsets(word, 'n')
+        lemma_names = []
+        for synset in synsets:
+            for entry in related_synsets(synset):
+                lemma_names += entry.lemma_names()
+        print word_list_without_duplicates(lemma_names),
+
+        print "--"+word.upper()+"--VERB--",
+        synsets = wn.synsets(word, 'v')
+        lemma_names = []
+        for synset in synsets:
+            for entry in related_synsets(synset):
+                lemma_names += entry.lemma_names()
+        print word_list_without_duplicates(lemma_names),
+
+        print "--"+word.upper()+"--ADJ--",
+        token_a = wn.synsets(word, 'a')
+        lemma_names = []
+        for entry in token_a:
+            lemma_names += entry.lemma_names()
+        print word_list_without_duplicates(lemma_names),
+
+        print "--"+word.upper()+"--ADV--",
+        token_r = wn.synsets(word, 'r')
+        lemma_names = []
+        for entry in token_r:
+            lemma_names += entry.lemma_names()
+        print word_list_without_duplicates(lemma_names),
+
         print " "
         print " "
 

--- a/auto_c_hypo.py
+++ b/auto_c_hypo.py
@@ -24,8 +24,7 @@ def return_words_two(entry):
 
 
 #loop
-loop = 1
-while loop == 1:
+while True:
 
     #input system
     input = raw_input("analyze: ")
@@ -97,4 +96,4 @@ while loop == 1:
         print " "
         print " ".join(words)
         print " "
-        loop = 0
+        break

--- a/auto_c_hypo.py
+++ b/auto_c_hypo.py
@@ -26,10 +26,10 @@ def return_words_two(entry):
 while True:
 
     #input system
-    input = raw_input("analyze: ")
+    input_text = raw_input("analyze: ")
 
     #analyzer
-    split_input = input.split()
+    split_input = input_text.split()
     print " "
     for word in split_input:
         try:
@@ -91,7 +91,7 @@ while True:
     print words
 
     #exiter
-    if input == "  ":
+    if input_text == "  ":
         print " "
         print " ".join(words)
         print " "

--- a/auto_c_hypo.py
+++ b/auto_c_hypo.py
@@ -4,7 +4,6 @@ import re
 
 #bank
 words = []
-joined = " "
 
 #parsing utilities
 def return_words_one(entry):


### PR DESCRIPTION
Yo! I broke my changes into four commits. The first three are pretty minimal/cosmetic, the last one is a little more meaningful.

You should be able to view the changes in each commit separately by clicking on each commit message below. This will also show you the full commit message, which tries to explain what the change is about.

The biggest change was to replace `return_words_one` and `return_words_two` with a new way of getting words out of synsets: `synset.lemma_names()`. This does change the output of the program--I believe it outputs *more* variations than before, and is not missing any that it previously had, but might be informative to run some tests comparing the two.

Some questions:
- I noticed that the way that you get adjective and adverb variations does not involve hyponyms, meronyms, etc. Is this on purpose? Is it because they don't exist for those parts of speech?
- Reading online, it sounds like holonym is the opposite or meronym. E.g. in the pair (finger, hand), finger is a meronym of hand, and hand is a holonym of finger. Does this mean that holonyms should not be a part of the variations list? I guess the linguistic sense of "specificity" is not the same as the poetic sense / the intention of the tool, so maybe this does not matter?